### PR TITLE
Add Typescript typedefs for the `upload` command

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+declare namespace Cypress {
+  interface Chainable<Subject = any> {
+    /**
+     * Command to upload a file to a specified
+     * @param file File contents to upload
+     * @param fileName File name to use
+     * @param mimeType MIME type of the uploaded file
+     */
+    upload(file, fileName, mimeType): Chainable<Subject>;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 declare namespace Cypress {
   interface Chainable<Subject = any> {
     /**
-     * Command to upload a file to a specified
+     * Command to upload a file to the given element
      * @param file File contents to upload
-     * @param fileName File name to use
+     * @param fileName File name to use for the upload
      * @param mimeType MIME type of the uploaded file
      */
     upload(file, fileName, mimeType): Chainable<Subject>;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "e2e",
     "test"
   ],
+  "types": "./index.d.ts",
   "author": "abramenal <pavel.auramenka@gmail.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This allows Typescript users to use `cy.upload` without issues and to have autocomplete for it.