### PR TITLE
fix: use utf8 as default encoding for PDF files

### DIFF
--- a/src/helpers/getValidEncoding.js
+++ b/src/helpers/getValidEncoding.js
@@ -22,7 +22,7 @@ export default fileName => {
     /*
      * Other extensions that are not supported by cy.fixture by default:
      */
-    pdf: 'base64',
+    pdf: 'utf8',
   };
 
   const extension = fileName.slice(fileName.lastIndexOf('.') + 1);


### PR DESCRIPTION
PDF files can contain non ASCII characters, which will result in an `InvalidCharacterError` when the base64 gets decoded using `atob`. I'd therefore propose utf8 as the preset for PDFs instead.