### PR TITLE
Add VCF file support

### DIFF
--- a/src/helpers/getValidEncoding.js
+++ b/src/helpers/getValidEncoding.js
@@ -23,6 +23,7 @@ export default fileName => {
      * Other extensions that are not supported by cy.fixture by default:
      */
     pdf: 'utf8',
+    vcf: 'utf8',
   };
 
   const extension = fileName.slice(fileName.lastIndexOf('.') + 1);


### PR DESCRIPTION
Closes #66 
FYI @xiaomeidan in v3.1.1 it will work without setting `encoding` explicitly, like:

```
cy.fixture('user.vcf').then(fileContent => {
  cy.get('input[type="file"]').upload(
    { fileContent, fileName: 'user.vcf', mimeType: 'text/vcard' },
    { subjectType: 'input' },
  );
});
```