### PR TITLE
Make processingOpts optional in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,6 @@ declare namespace Cypress {
      * @param fileOrArray Single or multiple object(s) representing file data
      * @param processingOpts Object representing processing options
      */
-    upload(fileOrArray: FileData | FileData[], processingOpts: FileProcessingOptions): Chainable<Subject>;
+    upload(fileOrArray: FileData | FileData[], processingOpts?: FileProcessingOptions): Chainable<Subject>;
   }
 }


### PR DESCRIPTION
Hi :wave: Thanks for the superb lib, it really saved my bacon 😊 

Seems like this options object is optional so we can make it optional in the typings too.