### PR TITLE
Trigger dragenter before dragover

### DIFF
--- a/src/handlers/handleDragDrop.js
+++ b/src/handlers/handleDragDrop.js
@@ -1,25 +1,15 @@
 export default ({ subject, force }, { files }) => {
+  const eventPayload = {
+    force,
+    dataTransfer: {
+      files,
+      types: ['Files'],
+    },
+  };
+
   return cy
     .wrap(subject, { log: false })
-    .trigger('dragenter', {
-      force,
-      dataTransfer: {
-        files,
-        types: ['Files'],
-      },
-    })
-    .trigger('drop', {
-      force,
-      dataTransfer: {
-        files,
-        types: ['Files'],
-      },
-    })
-    .trigger('dragleave', {
-      force,
-      dataTransfer: {
-        files,
-        types: ['Files'],
-      },
-    });
+    .trigger('dragenter', eventPayload)
+    .trigger('drop', eventPayload)
+    .trigger('dragleave', eventPayload);
 };

--- a/src/handlers/handleDragDrop.js
+++ b/src/handlers/handleDragDrop.js
@@ -1,16 +1,25 @@
 export default ({ subject, force }, { files }) => {
-  cy.wrap(subject, { log: false }).trigger('dragenter', {
-    force,
-    dataTransfer: {
-      files,
-      types: ['Files'],
-    },
-  });
-  cy.wrap(subject, { log: false }).trigger('drop', {
-    force,
-    dataTransfer: {
-      files,
-      types: ['Files'],
-    },
-  });
+  return cy
+    .wrap(subject, { log: false })
+    .trigger('dragenter', {
+      force,
+      dataTransfer: {
+        files,
+        types: ['Files'],
+      },
+    })
+    .trigger('drop', {
+      force,
+      dataTransfer: {
+        files,
+        types: ['Files'],
+      },
+    })
+    .trigger('dragleave', {
+      force,
+      dataTransfer: {
+        files,
+        types: ['Files'],
+      },
+    });
 };

--- a/src/handlers/handleDragDrop.js
+++ b/src/handlers/handleDragDrop.js
@@ -1,4 +1,11 @@
-export default ({ subject, force }, { files }) =>
+export default ({ subject, force }, { files }) => {
+  cy.wrap(subject, { log: false }).trigger('dragenter', {
+    force,
+    dataTransfer: {
+      files,
+      types: ['Files'],
+    },
+  });
   cy.wrap(subject, { log: false }).trigger('drop', {
     force,
     dataTransfer: {
@@ -6,3 +13,4 @@ export default ({ subject, force }, { files }) =>
       types: ['Files'],
     },
   });
+};


### PR DESCRIPTION
In our codebase, we rely on `dragenter` occurring before `drop`, and that's also the cycle that would be expected out of an actual user. This PR adds a `dragenter` event before it triggers `drop`.