### PR TITLE
Allow empty fileContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ cySubject.upload(fileOrArray, processingOpts);
 - {String} `subjectType` – target (aka subject) element kind: `'drag-n-drop'` component or plain HTML `'input'` element. Defaults to `'input'`
 - {String} `subjectNature` – target element nature: `'dom'` represents regular DOM elements, `'shadow'` stands for using elements within Shadow DOM. Defaults to `'dom'`
 - {Boolean} `force` – (optional) same as for [`cy.trigger`][cy.trigger] it enforces events triggering on HTML subject element. Usually this is necessary when you use hidden HTML controls for your file upload. Defaults to `false`
+- {Boolean} `allowEmpty` - (optional) when true, do not throw an error if `fileContent` is zero length. Defaults to `false`
 
 ## Recipes
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare namespace Cypress {
     subjectType: 'input' | 'drag-n-drop';
     subjectNature?: 'dom' | 'shadow';
     force?: boolean;
+    allowEmpty?: boolean;
   }
 
   interface Chainable<Subject> {

--- a/recipes/shadow-dom-native/cypress/integration/file-input.spec.js
+++ b/recipes/shadow-dom-native/cypress/integration/file-input.spec.js
@@ -46,4 +46,19 @@ describe('Attach file to a shadow dom input element', () => {
         .shadowContains('cy-2.png');
     });
   });
+
+  it('successfully uploads an empty file when allowEmpty is true', () => {
+    cy.fixture('empty.txt', 'base64').then(fileContent => {
+      cy.document({ log: false })
+        .shadowGet('file-input input', { selectMultiple: false })
+        .upload(
+          { fileContent, fileName: 'empty.txt', mimeType: 'text/plain' },
+          { subjectNature: 'shadow', subjectType: 'input', allowEmpty: true },
+        );
+
+      cy.document({ log: false })
+        .shadowGet('file-input ul')
+        .shadowContains('empty.txt');
+    });
+  });
 });

--- a/src/error.js
+++ b/src/error.js
@@ -23,6 +23,10 @@ export const ERR_TYPES = {
     message: '"force" is not valid',
     tip: 'Please look into docs to find supported "force" values',
   },
+  INVALID_ALLOW_EMPTY: {
+    message: '"allowEmpty" is not valid',
+    tip: 'Please look into docs to find supported "allowEmpty" values',
+  },
   INVALID_FILE: {
     message: 'One or more field is invalid within given file(s)',
     tip: 'Please look into docs to find supported "fileOrArray" values',

--- a/src/upload.js
+++ b/src/upload.js
@@ -6,15 +6,19 @@ const PROCESSING_OPTIONS_DEFAULTS = {
   subjectType: 'input',
   subjectNature: 'dom',
   force: false,
+  allowEmpty: false,
 };
 
 export default (subject, fileOrArray, processingOptions) =>
   cy.window({ log: false }).then(async window => {
-    const { subjectType, subjectNature, force } = ensureDefaults(processingOptions, PROCESSING_OPTIONS_DEFAULTS);
-    validateOptions({ subjectType, subjectNature, force });
+    const { subjectType, subjectNature, force, allowEmpty } = ensureDefaults(
+      processingOptions,
+      PROCESSING_OPTIONS_DEFAULTS,
+    );
+    validateOptions({ subjectType, subjectNature, force, allowEmpty });
     /* Subject validation depends on options validation so required to go in this exact order */
     validateSubject({ subject, subjectNature, subjectType });
-    validateFiles(fileOrArray);
+    validateFiles(fileOrArray, allowEmpty);
 
     const filesToUpload = await createFilesAsync({
       files: Array.isArray(fileOrArray) ? fileOrArray : [fileOrArray],
@@ -31,9 +35,10 @@ export default (subject, fileOrArray, processingOptions) =>
         subjectNature,
         files: filesToUpload,
         force,
+        allowEmpty,
       }),
     });
 
     const handleFileUpload = getHandler({ subjectType, subjectNature });
-    handleFileUpload({ window, subject, force }, { files: filesToUpload });
+    handleFileUpload({ window, subject, force, allowEmpty }, { files: filesToUpload });
   });

--- a/src/validators/validateFiles.js
+++ b/src/validators/validateFiles.js
@@ -4,7 +4,7 @@ export default fileOrArray => {
   const filesToValidate = Array.isArray(fileOrArray) ? fileOrArray : [fileOrArray];
   /* Note: "encoding" field is not mandatory */
   filesToValidate.forEach(({ fileContent, fileName, mimeType }) => {
-    if (!fileContent || !fileName || !mimeType) {
+    if (fileContent === undefined || !fileName || !mimeType) {
       throw new InternalError(ERR_TYPES.INVALID_FILE);
     }
   });

--- a/src/validators/validateFiles.js
+++ b/src/validators/validateFiles.js
@@ -1,10 +1,11 @@
 import { ERR_TYPES, InternalError } from '../error';
 
-export default fileOrArray => {
+export default (fileOrArray, allowEmpty) => {
   const filesToValidate = Array.isArray(fileOrArray) ? fileOrArray : [fileOrArray];
   /* Note: "encoding" field is not mandatory */
   filesToValidate.forEach(({ fileContent, fileName, mimeType }) => {
-    if (fileContent === undefined || !fileName || !mimeType) {
+    const fileContentValid = allowEmpty ? fileContent !== undefined : !!fileContent;
+    if (!fileContentValid || !fileName || !mimeType) {
       throw new InternalError(ERR_TYPES.INVALID_FILE);
     }
   });

--- a/src/validators/validateOptions.js
+++ b/src/validators/validateOptions.js
@@ -1,7 +1,7 @@
 import { SUBJECT_TYPE, SUBJECT_NATURE } from '../constants';
 import { ERR_TYPES, InternalError } from '../error';
 
-export default ({ subjectType, subjectNature, force }) => {
+export default ({ subjectType, subjectNature, force, allowEmpty }) => {
   if (Object.values(SUBJECT_TYPE).indexOf(subjectType) === -1) {
     throw new InternalError(ERR_TYPES.INVALID_SUBJECT_TYPE);
   }
@@ -12,5 +12,9 @@ export default ({ subjectType, subjectNature, force }) => {
 
   if (typeof force !== 'boolean') {
     throw new InternalError(ERR_TYPES.INVALID_FORCE);
+  }
+
+  if (typeof allowEmpty !== 'boolean') {
+    throw new InternalError(ERR_TYPES.INVALID_ALLOW_EMPTY);
   }
 };


### PR DESCRIPTION
### Current behavior:

Attempting to upload an empty file throws an error.

### Desired behavior:

To be able to upload an empty file.

### Steps to reproduce

cy.get('[data-cy="file-input"]').upload({ '', fileName: 'empty.txt', mimeType: 'text/plain' });

### Versions

cypress-file-upload 3.4.0
