### PR TITLE
properly build data transfer object

### DIFF
--- a/src/attachFile.js
+++ b/src/attachFile.js
@@ -25,7 +25,7 @@ export default function attachFile(subject, fixture, processingOptions) {
         file => {
           validateFile(file, allowEmpty);
 
-          attachFileToElement(subject, { file, subjectType, force: forceValue });
+          attachFileToElement(subject, { file, subjectType, force: forceValue, window });
 
           Cypress.log({
             name: 'attachFile',

--- a/src/helpers/attachFileToElement.js
+++ b/src/helpers/attachFileToElement.js
@@ -1,7 +1,7 @@
 import { SUBJECT_TYPE, EVENTS_BY_SUBJECT_TYPE } from '../constants';
 
-export default function(subject, { file, subjectType, force }) {
-  const dataTransfer = new DataTransfer();
+export default function(subject, { file, subjectType, force, window }) {
+  const dataTransfer = new window.DataTransfer();
   dataTransfer.items.add(file);
 
   if (subjectType === SUBJECT_TYPE.INPUT) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,14 +23,4 @@ declare namespace Cypress {
      */
     attachFile(fixture: String | FixtureData, processingOpts?: FileProcessingOptions): Chainable<Subject>;
   }
-
-  // TODO check if removing Chainable<Subject> extension drops 'ES5' target supportt
-  interface Chainable<JQuery = any> {
-    /**
-     * Command to attach file(s) to given HTML element as subject
-     * @param fixture file to attach
-     * @param processingOpts affects the way of fixture processing
-     */
-    attachFile(fixture: String | FixtureData, processingOpts?: FileProcessingOptions): Chainable<JQuery>;
-  }
 }


### PR DESCRIPTION
Fix for this issue: https://github.com/abramenal/cypress-file-upload/issues/181

The problem was when creating the DataTranfer object we did not use the constructor from the window that host the site being tested and It was failing the validation.