### PR TITLE
[Typo] in README.md `fixtures` -> `fixture`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cy.get('[data-cy="file-input"]').attachFile({ filePath: data, fileName: 'users.j
 /* If your file needs special processing not supported out of the box, you can pass fileContent directly */
 
 const special = 'file.spss';
-cy.fixtures(special, 'binary')
+cy.fixture(special, 'binary')
   .then(Cypress.Blob.binaryStringToBlob)
   .then((fileContent) => {
     cy.get('[data-cy="file-input"]').attachFile({ fileContent, filePath: special, encoding: 'utf-8' });
@@ -79,7 +79,7 @@ cy.fixtures(special, 'binary')
 /* when providing fileContent is possible to ignore filePath but fileName and mime type must be provided */
 
 const special = 'file.spss';
-cy.fixtures(special, 'binary')
+cy.fixture(special, 'binary')
   .then(Cypress.Blob.binaryStringToBlob)
   .then((fileContent) => {
     cy.get('[data-cy="file-input"]').attachFile({ fileContent, fileName: 'special', mimeType: 'application/octet-stream', encoding: 'utf-8' });


### PR DESCRIPTION
Hello, Team! 

This PR about fixing typo inside README.file
During my last installation, I found this issue when I was doing copy/paste of this block

```
const special = 'file.spss';
cy.fixtures(special, 'binary')
  .then(Cypress.Blob.binaryStringToBlob)
  .then((fileContent) => {
    cy.get('[data-cy="file-input"]').attachFile({ fileContent, filePath: special, encoding: 'utf-8' });
})
```

as you can see `fixtures` word is in plural form but should be in single according to the cypress [documentation](https://docs.cypress.io/api/commands/fixture.html#Syntax) and 

and inside the library
![image](https://user-images.githubusercontent.com/13170022/89897779-da9af600-dbdf-11ea-816a-6100615c928c.png)

So it is the only way to make it work to use single form `fixture`

@abramenal  thank you in advance for approving!

Best 
Zhenja