### PR TITLE
Update Blob use to be compatible with Cypress 5.0

### DIFF
--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -2,12 +2,24 @@ import { extname } from 'path';
 
 import { ENCODING, FILE_EXTENSION } from './constants';
 
+let wrapBlob = blob => {
+  // Cypress version 5 assigns a function with a compatibility warning
+  // to blob.then, but that makes the Blob actually thenable. We have
+  // to remove that to Promise.resolve not treat it as thenable.
+  //
+  // eslint-disable-next-line no-param-reassign
+  delete blob.then;
+  return Cypress.Promise.resolve(blob);
+};
+
+if (Cypress.version < '5.0.0') {
+  wrapBlob = blob => blob;
+}
+
 const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.ASCII]: fileContent => Cypress.Promise.resolve(fileContent),
-  [ENCODING.BASE64]: (fileContent, mimeType) =>
-    Cypress.Promise.try(() => Cypress.Blob.base64StringToBlob(fileContent, mimeType)),
-  [ENCODING.BINARY]: (fileContent, mimeType) =>
-    Cypress.Promise.try(() => Cypress.Blob.binaryStringToBlob(fileContent, mimeType)),
+  [ENCODING.BASE64]: (fileContent, mimeType) => wrapBlob(Cypress.Blob.base64StringToBlob(fileContent, mimeType)),
+  [ENCODING.BINARY]: (fileContent, mimeType) => wrapBlob(Cypress.Blob.binaryStringToBlob(fileContent, mimeType)),
   [ENCODING.HEX]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.LATIN1]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.UTF8]: fileContent => Cypress.Promise.resolve(fileContent),

--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -5,9 +5,9 @@ import { ENCODING, FILE_EXTENSION } from './constants';
 const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.ASCII]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.BASE64]: (fileContent, mimeType) =>
-    Cypress.Promise.resolve(Cypress.Blob.base64StringToBlob(fileContent, mimeType)),
+    Cypress.Promise.try(Cypress.Blob.base64StringToBlob(fileContent, mimeType)),
   [ENCODING.BINARY]: (fileContent, mimeType) =>
-    Cypress.Promise.resolve(Cypress.Blob.binaryStringToBlob(fileContent, mimeType)),
+    Cypress.Promise.try(Cypress.Blob.binaryStringToBlob(fileContent, mimeType)),
   [ENCODING.HEX]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.LATIN1]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.UTF8]: fileContent => Cypress.Promise.resolve(fileContent),

--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -1,21 +1,19 @@
 import { extname } from 'path';
-import semver from 'semver';
 
 import { ENCODING, FILE_EXTENSION } from './constants';
 
-let wrapBlob = blob => {
+const wrapBlob = blob => {
   // Cypress version 5 assigns a function with a compatibility warning
   // to blob.then, but that makes the Blob actually thenable. We have
   // to remove that to Promise.resolve not treat it as thenable.
-  //
+  if (blob instanceof Cypress.Promise) {
+    return blob;
+  }
+
   // eslint-disable-next-line no-param-reassign
   delete blob.then;
   return Cypress.Promise.resolve(blob);
 };
-
-if (semver.lt(Cypress.version, '5.0.0')) {
-  wrapBlob = blob => blob;
-}
 
 const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.ASCII]: fileContent => Cypress.Promise.resolve(fileContent),

--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -5,9 +5,9 @@ import { ENCODING, FILE_EXTENSION } from './constants';
 const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.ASCII]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.BASE64]: (fileContent, mimeType) =>
-    Cypress.Promise.try(Cypress.Blob.base64StringToBlob(fileContent, mimeType)),
+    Cypress.Promise.try(() => Cypress.Blob.base64StringToBlob(fileContent, mimeType)),
   [ENCODING.BINARY]: (fileContent, mimeType) =>
-    Cypress.Promise.try(Cypress.Blob.binaryStringToBlob(fileContent, mimeType)),
+    Cypress.Promise.try(() => Cypress.Blob.binaryStringToBlob(fileContent, mimeType)),
   [ENCODING.HEX]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.LATIN1]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.UTF8]: fileContent => Cypress.Promise.resolve(fileContent),

--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -4,8 +4,10 @@ import { ENCODING, FILE_EXTENSION } from './constants';
 
 const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.ASCII]: fileContent => Cypress.Promise.resolve(fileContent),
-  [ENCODING.BASE64]: (fileContent, mimeType) => Cypress.Blob.base64StringToBlob(fileContent, mimeType),
-  [ENCODING.BINARY]: (fileContent, mimeType) => Cypress.Blob.binaryStringToBlob(fileContent, mimeType),
+  [ENCODING.BASE64]: (fileContent, mimeType) =>
+    Cypress.Promise.resolve(Cypress.Blob.base64StringToBlob(fileContent, mimeType)),
+  [ENCODING.BINARY]: (fileContent, mimeType) =>
+    Cypress.Promise.resolve(Cypress.Blob.binaryStringToBlob(fileContent, mimeType)),
   [ENCODING.HEX]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.LATIN1]: fileContent => Cypress.Promise.resolve(fileContent),
   [ENCODING.UTF8]: fileContent => Cypress.Promise.resolve(fileContent),

--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -1,4 +1,5 @@
 import { extname } from 'path';
+import semver from 'semver';
 
 import { ENCODING, FILE_EXTENSION } from './constants';
 
@@ -12,7 +13,7 @@ let wrapBlob = blob => {
   return Cypress.Promise.resolve(blob);
 };
 
-if (Cypress.version < '5.0.0') {
+if (semver.lt(Cypress.version, '5.0.0')) {
   wrapBlob = blob => blob;
 }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cypress": ">3.0.0"
   },
   "dependencies": {
-    "mime": "^2.4.4"
+    "mime": "^2.4.4",
+    "semver": "^7.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "cypress": ">3.0.0"
   },
   "dependencies": {
-    "mime": "^2.4.4",
-    "semver": "^7.3.2"
+    "mime": "^2.4.4"
   }
 }


### PR DESCRIPTION
Wraps return value of `Cypress.Blob.base64StringToBlob()` in a `Cypress.Promise.resolve`, which will allow us to treat it as a Promise no matter what. If it's already a Promise, as it was in Cypress <=4, this will be also be compatible. 

Fixes #214