### PR TITLE
fix: delete fileContent.then in getFileContent to avoid error from cypress 5.0

### DIFF
--- a/lib/file/common.js
+++ b/lib/file/common.js
@@ -1,0 +1,14 @@
+export const wrapBlob = blob => {
+  // Cypress version 5 assigns a function with a compatibility warning
+  // to blob.then, but that makes the Blob actually thenable. We have
+  // to remove that to Promise.resolve not treat it as thenable.
+  if (blob instanceof Cypress.Promise) {
+    return blob;
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  delete blob.then;
+  return Cypress.Promise.resolve(blob);
+};
+
+export default { wrapBlob };

--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -2,18 +2,7 @@ import { extname } from 'path';
 
 import { ENCODING, FILE_EXTENSION } from './constants';
 
-const wrapBlob = blob => {
-  // Cypress version 5 assigns a function with a compatibility warning
-  // to blob.then, but that makes the Blob actually thenable. We have
-  // to remove that to Promise.resolve not treat it as thenable.
-  if (blob instanceof Cypress.Promise) {
-    return blob;
-  }
-
-  // eslint-disable-next-line no-param-reassign
-  delete blob.then;
-  return Cypress.Promise.resolve(blob);
-};
+import { wrapBlob } from './common';
 
 const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.ASCII]: fileContent => Cypress.Promise.resolve(fileContent),

--- a/lib/file/getFileContent.js
+++ b/lib/file/getFileContent.js
@@ -1,7 +1,9 @@
+import { wrapBlob } from './common';
+
 export default function getFileContent({ filePath, fileContent, fileEncoding }) {
   // allows users to provide file content.
   if (fileContent) {
-    return Cypress.Promise.resolve(fileContent);
+    return wrapBlob(fileContent);
   }
 
   return Cypress.cy.fixture(filePath, fileEncoding);


### PR DESCRIPTION
Use `wrapBlob` in `getFileContent` to avoid cypress 5.0 error: `binaryStringToBlob() no longer returns a Promise. Update the use of binaryStringToBlob() to expect a returned Blob`