### PR TITLE
fix(docs): Make it clear that the fixture file can be any file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Now you are ready to actually test uploading. Here are some basic examples:
 ```javascript
 /* Plain HTML input */
 
-const yourFixturePath = 'data.json';
+const yourFixturePath = 'data.json'; // the file to be uploaded, from the cypress/fixtures/ directory
 cy.get('[data-cy="file-input"]').attachFile(yourFixturePath);
 
 /* Drag-n-drop component */


### PR DESCRIPTION
...because I thought that, in the first example, the JSON file was metadata about the file to upload, and wasted a lot of time because of this misunderstanding.

I understood thanks to this StackOverflow answer: https://stackoverflow.com/a/62204487/592254