### PR TITLE
Allow fileContent without filePath in types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,17 @@
 /// <reference types="cypress" />
 
 declare namespace Cypress {
-  interface FixtureData {
-    filePath: String;
+  type FixtureData = {
+    filePath: string;
     fileContent?: Blob;
     fileName?: string;
-    encoding?: String;
-    mimeType?: String;
+    encoding?: string;
+    mimeType?: string;
+  } | {
+    fileContent: Blob;
+    fileName: string;
+    mimeType: string;
+    encoding?: string;
   }
 
   interface FileProcessingOptions {


### PR DESCRIPTION
The documentation states

> when providing fileContent is possible to ignore filePath but fileName and mime type must be provided

The previous type coverage didn't allow for that.