### PR TITLE
Update README to include reference to  "cypress-file-upload" in .tsconfig setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import 'cypress-file-upload';
 Note: With Typescript, ensure the following is in your `cypress\tsconfig.json` file:
 ```
 "compilerOptions": {
-  "types": ["cypress"]
+  "types": ["cypress", "cypress-file-upload"]
 ```
 
 Now you are ready to actually test uploading. Here are some basic examples:


### PR DESCRIPTION
This solves the issue of intellisense not recognising the `cypress-file-upload` methods on the `cypress`object.

Issue/solution described here: https://github.com/abramenal/cypress-file-upload/issues/202#issuecomment-690093574