### PR TITLE
feat: do not preserve existing files

### DIFF
--- a/recipes/react-html5-input/cypress/integration/repeated.spec.js
+++ b/recipes/react-html5-input/cypress/integration/repeated.spec.js
@@ -1,0 +1,14 @@
+describe('Repeated uploads', () => {
+  beforeEach(() => {
+    cy.visit('/');
+
+    cy.get('[data-cy="input"]').attachFile('cy.png');
+  });
+
+  it('does not preserve previously attached files', () => {
+    cy.get('[data-cy="input"]').attachFile('test.json');
+
+    cy.get('li').should('have.length', 1);
+    cy.get('li').contains('test.json');
+  });
+});

--- a/src/helpers/attachFileToElement.js
+++ b/src/helpers/attachFileToElement.js
@@ -1,16 +1,6 @@
 import { dispatchEvent } from '../../lib/dom';
 import { SUBJECT_TYPE, EVENTS_BY_SUBJECT_TYPE } from '../constants';
 
-function attachFilesToElement(element, dataTransfer) {
-  if (element.files && element.files.length > 0) {
-    /* Keep files that were attached before */
-    Array.prototype.forEach.call(element.files, f => dataTransfer.items.add(f));
-  }
-
-  // eslint-disable-next-line no-param-reassign
-  element.files = dataTransfer.files;
-}
-
 function dispatchEvents(element, events, dataTransfer) {
   events.forEach(event => {
     dispatchEvent(element, event, dataTransfer);
@@ -23,7 +13,7 @@ export default function attachFileToElement(subject, { files, subjectType, force
 
   if (subjectType === SUBJECT_TYPE.INPUT) {
     const inputElement = subject[0];
-    attachFilesToElement(inputElement, dataTransfer);
+    inputElement.files = dataTransfer.files;
 
     if (force) {
       dispatchEvents(inputElement, EVENTS_BY_SUBJECT_TYPE[subjectType], dataTransfer);
@@ -37,14 +27,14 @@ export default function attachFileToElement(subject, { files, subjectType, force
      */
     if (inputElements.length === 1) {
       const inputElement = inputElements[0];
-      attachFilesToElement(inputElement, dataTransfer);
+      inputElement.files = dataTransfer.files;
 
       if (force) {
         dispatchEvents(inputElement, EVENTS_BY_SUBJECT_TYPE[subjectType], dataTransfer);
       }
     } else {
       const inputElement = subject[0];
-      attachFilesToElement(inputElement, dataTransfer);
+      inputElement.files = dataTransfer.files;
 
       if (force) {
         dispatchEvents(inputElement, EVENTS_BY_SUBJECT_TYPE[subjectType], dataTransfer);


### PR DESCRIPTION
#### Checklist:

- [x] No linting issues
- [x] Commits are compliant with commitizen
- [x] CI tests have passed
- [x] Documentation updated

#### Summary of changes

Do not preserve existing files.

This functionality was making sense when doing chaining calls, but now it is redundant. More than that, it is different from user may experience when doing same actions manually.

#### Linked issues

Closes #264
