### PR TITLE
allow setting a files lastModified property

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,12 @@ const special = 'file.spss';
 cy.fixture(special, 'binary')
   .then(Cypress.Blob.binaryStringToBlob)
   .then(fileContent => {
-    cy.get('[data-cy="file-input"]').attachFile({ fileContent, filePath: special, encoding: 'utf-8' });
+    cy.get('[data-cy="file-input"]').attachFile({
+      fileContent,
+      filePath: special,
+      encoding: 'utf-8',
+      lastModified: new Date().getTime()
+    });
   });
 ```
 
@@ -127,6 +132,7 @@ cy.fixture('file.spss', 'binary')
       fileName: 'whatever',
       mimeType: 'application/octet-stream',
       encoding: 'utf-8',
+      lastModified: new Date().getTime(),
     });
   });
 ```
@@ -166,8 +172,14 @@ const fileName = 'upload_1.xlsx';
 cy.fixture(fileName, 'binary')
     .then(Cypress.Blob.binaryStringToBlob)
     .then(fileContent => {
-      cy.get('#input_upload_file').attachFile({ fileContent, fileName, mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', encoding:'utf8' })
-})
+      cy.get('#input_upload_file').attachFile({
+        fileContent,
+        fileName,
+        mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        encoding:'utf8',
+        lastModified: new Date().getTime()
+      })
+    })
 
 // wait for the 'upload_endpoint' request, and leave a 2 minutes delay before throwing an error
 cy.wait('@upload', { requestTimeout: 120000 });
@@ -200,6 +212,7 @@ cySubject.attachFile(fixture, processingOpts);
 - {Blob} `fileContent` - the binary content of the file to be attached
 - {string} `mimeType` - file [MIME][mime] type. By default, it gets resolved automatically based on file extension. Learn more about [mime](https://github.com/broofa/node-mime)
 - {string} `encoding` - normally [`cy.fixture`][cy.fixture] resolves encoding automatically, but in case it cannot be determined you can provide it manually. For a list of allowed encodings, see [here](https://github.com/abramenal/cypress-file-upload/blob/master/lib/file/constants.js#L1)
+- {number} `lastModified` - The unix timestamp of the lastModified value for the file.  Defaults to current time. Can be generated from `new Date().getTime()` or `Date.now()`
 
 `processingOpts` contains following properties:
 

--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -18,7 +18,7 @@ const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.UTF_16LE]: fileContent => Cypress.Promise.resolve(fileContent),
 };
 
-export default function getFileBlobAsync({ fileName, fileContent, mimeType, encoding, window }) {
+export default function getFileBlobAsync({ fileName, fileContent, mimeType, encoding, window, lastModified }) {
   const getBlob = ENCODING_TO_BLOB_GETTER[encoding];
 
   return getBlob(fileContent, mimeType).then(blob => {
@@ -30,7 +30,7 @@ export default function getFileBlobAsync({ fileName, fileContent, mimeType, enco
     }
 
     // we must use the file constructor from the subject window so this check `file instanceof File`, can pass
-    const file = new window.File([blobContent], fileName, { type: mimeType });
+    const file = new window.File([blobContent], fileName, { type: mimeType, lastModified });
     return file;
   });
 }

--- a/lib/file/resolveFile.js
+++ b/lib/file/resolveFile.js
@@ -4,10 +4,11 @@ import getFileEncoding from './getFileEncoding';
 import getFileBlobAsync from './getFileBlobAsync';
 
 export default function resolveFile(fixture, window) {
-  const { filePath, encoding, mimeType, fileName } = fixture;
+  const { filePath, encoding, mimeType, fileName, lastModified } = fixture;
 
   const fileMimeType = mimeType || getFileMimeType(filePath);
   const fileEncoding = encoding || getFileEncoding(filePath);
+  const fileLastModified = lastModified || Date.now();
 
   return new Cypress.Promise(resolve =>
     getFileContent({
@@ -21,6 +22,7 @@ export default function resolveFile(fixture, window) {
           fileName,
           mimeType: fileMimeType,
           encoding: fileEncoding,
+          lastModified: fileLastModified,
           window,
         }),
       )

--- a/src/error.js
+++ b/src/error.js
@@ -27,6 +27,10 @@ export const ERR_TYPES = {
     message: 'given fixture file is empty',
     tip: 'Please make sure you provide correct file or explicitly set "allowEmpty" to true',
   },
+  INVALID_LAST_MODIFIED: {
+    message: '"lastModified" is not valid"',
+    tip: 'Please make sure you are passing a "number" `Date.now()` or `new Date().getTime()',
+  },
   MISSING_FILE_NAME_OR_PATH: {
     message: 'missing "filePath" or "fileName"',
     tip: 'Please make sure you are passing either "filePath" or "fileName"',

--- a/src/helpers/getFixtureInfo.js
+++ b/src/helpers/getFixtureInfo.js
@@ -16,5 +16,6 @@ export default function getFixtureInfo(fixtureInput) {
     mimeType: fixtureInput.mimeType || '',
     fileName: fixtureInput.fileName || path.basename(fixtureInput.filePath),
     fileContent: fixtureInput.fileContent,
+    lastModified: fixtureInput.lastModified,
   };
 }

--- a/src/validators/validateFixture.js
+++ b/src/validators/validateFixture.js
@@ -4,7 +4,7 @@ import { ENCODING } from '../../lib/file/constants';
 const ALLOWED_ENCODINGS = Object.values(ENCODING);
 
 export default function validateFixtures(fixture) {
-  const { filePath, fileName, encoding, mimeType, fileContent } = fixture;
+  const { filePath, fileName, encoding, mimeType, fileContent, lastModified } = fixture;
 
   if (encoding && !ALLOWED_ENCODINGS.includes(encoding)) {
     throw new InternalError(ERR_TYPES.INVALID_FILE_ENCODING);
@@ -20,6 +20,10 @@ export default function validateFixtures(fixture) {
 
   if (!filePath && !fileName) {
     throw new InternalError(ERR_TYPES.MISSING_FILE_NAME_OR_PATH);
+  }
+
+  if (lastModified && typeof lastModified !== 'number') {
+    throw new InternalError(ERR_TYPES.INVALID_LAST_MODIFIED);
   }
 
   return true;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@ declare namespace Cypress {
         fileName?: string;
         encoding?: FixtureEncoding;
         mimeType?: string;
+        lastModified?: number;
       };
 
   interface FileProcessingOptions {


### PR DESCRIPTION
#### Checklist:

- [X] No linting issues
- [x] Commits are compliant with commitizen
- [ ] CI tests have passed
- [X] Documentation updated

#### Summary of changes

This allows you to pass a lastModified attribute to be used for the file.  This is helpful for testing the uploading of duplicate files so they can have the same lastModified and fingerprint.


#### Linked issues

Closes #277 

