### PR TITLE
Fix Firefox Drag'n'Drop Functionality

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -1,2 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as isManualEventHandling } from './isManualEventHandling';
+export { default as isBrowserFirefox } from './isBrowserFirefox';

--- a/lib/browser/isBrowserFirefox.js
+++ b/lib/browser/isBrowserFirefox.js
@@ -1,0 +1,7 @@
+const BROWSER_FIREFOX = 'firefox';
+
+export default function isBrowserFirefox() {
+  const { name } = Cypress.browser;
+
+  return name === BROWSER_FIREFOX;
+}

--- a/src/helpers/attachFileToElement.js
+++ b/src/helpers/attachFileToElement.js
@@ -1,10 +1,24 @@
 import { dispatchEvent } from '../../lib/dom';
-import { SUBJECT_TYPE, EVENTS_BY_SUBJECT_TYPE } from '../constants';
+import { EVENTS_BY_SUBJECT_TYPE, SUBJECT_TYPE } from '../constants';
+import { isBrowserFirefox } from '../../lib/browser';
 
 function dispatchEvents(element, events, dataTransfer) {
   events.forEach(event => {
     dispatchEvent(element, event, dataTransfer);
   });
+}
+
+function getEventsBySubjectType(subjectType) {
+  const events = EVENTS_BY_SUBJECT_TYPE[subjectType];
+
+  /**
+   * @see https://github.com/abramenal/cypress-file-upload/issues/293
+   */
+  if (subjectType === SUBJECT_TYPE.DRAG_N_DROP && isBrowserFirefox()) {
+    events.push('change');
+  }
+
+  return events;
 }
 
 export default function attachFileToElement(subject, { files, subjectType, force, window }) {
@@ -16,7 +30,7 @@ export default function attachFileToElement(subject, { files, subjectType, force
     inputElement.files = dataTransfer.files;
 
     if (force) {
-      dispatchEvents(inputElement, EVENTS_BY_SUBJECT_TYPE[subjectType], dataTransfer);
+      dispatchEvents(inputElement, getEventsBySubjectType(subjectType), dataTransfer);
     }
   } else if (subjectType === SUBJECT_TYPE.DRAG_N_DROP) {
     const inputElements = subject[0].querySelectorAll('input[type="file"]');
@@ -30,14 +44,14 @@ export default function attachFileToElement(subject, { files, subjectType, force
       inputElement.files = dataTransfer.files;
 
       if (force) {
-        dispatchEvents(inputElement, EVENTS_BY_SUBJECT_TYPE[subjectType], dataTransfer);
+        dispatchEvents(inputElement, getEventsBySubjectType(subjectType), dataTransfer);
       }
     } else {
       const inputElement = subject[0];
       inputElement.files = dataTransfer.files;
 
       if (force) {
-        dispatchEvents(inputElement, EVENTS_BY_SUBJECT_TYPE[subjectType], dataTransfer);
+        dispatchEvents(inputElement, getEventsBySubjectType(subjectType), dataTransfer);
       }
     }
   }


### PR DESCRIPTION
#### Checklist:

- [x] No linting issues
- [x] Commits are compliant with commitizen
- [x] CI tests have passed
- [x] Documentation updated

#### Summary of changes

#290 broke Firefox compatibility. This PR adds a specific check to see if the Cypress runner broswer is Firefox to manually add `'change'` into the drag'n'drop list of events because its presence was casing duplication for Chrome (see #276). 

Draft PR instead of ready for review because we should probably add tests that try and repro some of these issues (either Chrome duplication, or Firefox upload functionality broken) so that we don't play whack-a-mole with patch PRs. 

#### Linked issues

Closes #293
