### PR TITLE
chore: enable Firefox testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
   pull_request: {}
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
       - run: npm run build
 
   test-e2e:
-    name: E2E tests
+    name: E2E tests (Chrome & Electron)
     needs: [build]
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.15.0-chrome86-ff82
@@ -70,27 +70,6 @@ jobs:
           browser: chrome
           headless: true
           wait-on: ${{ env.app_host }}
-      # - name: Run Firefox tests
-      #   uses: cypress-io/github-action@v2
-      #   with:
-      #     working-directory: ./recipes/${{ matrix.cwd }}
-      #     install: false
-      #     record: true
-      #     group: '${{ matrix.cwd }}/Firefox'
-      #     browser: firefox
-      #     headless: false
-      #     wait-on: ${{ env.app_host }}
-      # - name: Run Firefox headless tests
-      #   uses: cypress-io/github-action@v2
-      #   with:
-      #     working-directory: ./recipes/${{ matrix.cwd }}
-      #     install: false
-      #     record: true
-      #     group: '${{ matrix.cwd }}/Firefox (headless)'
-      #     ci-build-id: '${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}'
-      #     browser: firefox
-      #     headless: true
-      #     wait-on: ${{ env.app_host }}
       - name: Run Electron tests
         uses: cypress-io/github-action@v2
         with:
@@ -111,5 +90,58 @@ jobs:
           group: '${{ matrix.cwd }}/Electron (headless)'
           ci-build-id: '${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}'
           browser: electron
+          headless: true
+          wait-on: ${{ env.app_host }}
+
+  test-e2e-firefox:
+    name: E2E tests (Firefox)
+    needs: [build]
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node14.16.0-chrome89-ff86
+      options: --user 1001
+
+    env:
+      app_host: 'http://localhost:3000'
+      # pass the Dashboard record key as an environment variable
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      # pass GitHub token to allow accurately detecting a build vs a re-run build
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix:
+        cwd: [angularjs-ng-file-upload, react-dropzone, react-html5-input, shadow-dom-native]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gerred/actions/current-time@master
+      - run: npm ci
+      - run: npm run build
+      - name: Install dependencies and verify Cypress
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: ./recipes/${{ matrix.cwd }}
+          runTests: false
+      - name: Run web application
+        run: npm start & # & helps to run daemonized app
+        working-directory: ./recipes/${{ matrix.cwd }}
+      - name: Run Firefox tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: ./recipes/${{ matrix.cwd }}
+          install: false
+          record: true
+          group: '${{ matrix.cwd }}/Firefox'
+          browser: firefox
+          headless: false
+          wait-on: ${{ env.app_host }}
+      - name: Run Firefox headless tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: ./recipes/${{ matrix.cwd }}
+          install: false
+          record: true
+          group: '${{ matrix.cwd }}/Firefox (headless)'
+          ci-build-id: '${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}'
+          browser: firefox
           headless: true
           wait-on: ${{ env.app_host }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       # pass GitHub token to allow accurately detecting a build vs a re-run build
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
+      fail-fast: false
       matrix:
         cwd: [angularjs-ng-file-upload, react-dropzone, react-html5-input, shadow-dom-native]
 


### PR DESCRIPTION
#### Checklist:

- [x] No linting issues
- [x] Commits are compliant with commitizen
- [x] CI tests have passed
- [x] Documentation updated

#### Summary of changes

Long time ago Firefox tests were disabled on CI, which makes FF testing manual only (read "impossible"). This PR addresses this CI issue

Also this PR removes `fail-fast` behavior, so failure in a single matrix step won't fail all other in-progress steps.

#### Linked issues

#294
