### PR TITLE
refactor: replace node.js module imports with own implementations

### DIFF
--- a/lib/file/getFileBlobAsync.js
+++ b/lib/file/getFileBlobAsync.js
@@ -1,8 +1,7 @@
-import { extname } from 'path';
-
 import { ENCODING, FILE_EXTENSION } from './constants';
 
 import { wrapBlob } from './common';
+import getFileExt from './getFileExt';
 
 const ENCODING_TO_BLOB_GETTER = {
   [ENCODING.ASCII]: fileContent => Cypress.Promise.resolve(fileContent),
@@ -25,7 +24,7 @@ export default function getFileBlobAsync({ fileName, fileContent, mimeType, enco
     let blobContent = blob;
 
     // https://github.com/abramenal/cypress-file-upload/issues/175
-    if (extname(fileName).slice(1) === FILE_EXTENSION.JSON) {
+    if (getFileExt(fileName) === FILE_EXTENSION.JSON) {
       blobContent = JSON.stringify(fileContent, null, 2);
     }
 

--- a/lib/file/getFileEncoding.js
+++ b/lib/file/getFileEncoding.js
@@ -1,6 +1,5 @@
-import { extname } from 'path';
-
 import { ENCODING, FILE_EXTENSION } from './constants';
+import getFileExt from './getFileExt';
 
 /*
  * Copied from https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/fixture.coffee#L104
@@ -36,7 +35,7 @@ const EXTENSION_TO_ENCODING = {
 const DEFAULT_ENCODING = ENCODING.UTF8;
 
 export default function getFileEncoding(filePath) {
-  const extension = extname(filePath).slice(1);
+  const extension = getFileExt(filePath);
   const encoding = EXTENSION_TO_ENCODING[extension];
 
   return encoding || DEFAULT_ENCODING;

--- a/lib/file/getFileExt.js
+++ b/lib/file/getFileExt.js
@@ -1,0 +1,13 @@
+export default function getFileExt(filePath) {
+  if (!filePath) {
+    return '';
+  }
+
+  const pos = filePath.lastIndexOf('.');
+
+  if (pos === -1) {
+    return '';
+  }
+
+  return filePath.slice(pos + 1);
+}

--- a/lib/file/getFileMimeType.js
+++ b/lib/file/getFileMimeType.js
@@ -1,10 +1,10 @@
-import { extname } from 'path';
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { getType } from 'mime';
 
+import getFileExt from './getFileExt';
+
 export default function getFileMimeType(filePath) {
-  const extension = extname(filePath).slice(1);
+  const extension = getFileExt(filePath);
   const mimeType = getType(extension);
 
   return mimeType;

--- a/lib/file/getFileName.js
+++ b/lib/file/getFileName.js
@@ -1,0 +1,19 @@
+const UNIX_SEP = '/';
+const WIN_SEP = '\\';
+
+export default function getFileName(filePath) {
+  if (!filePath) {
+    return '';
+  }
+
+  let indexSep = filePath.lastIndexOf(UNIX_SEP);
+  if (indexSep === -1) {
+    indexSep = filePath.lastIndexOf(WIN_SEP);
+  }
+
+  if (indexSep === -1) {
+    return filePath;
+  }
+
+  return filePath.slice(indexSep + 1);
+}

--- a/lib/file/index.js
+++ b/lib/file/index.js
@@ -1,5 +1,7 @@
 export { default as getFileBlobAsync } from './getFileBlobAsync';
-export { default as getFileEncoding } from './getFileEncoding';
-export { default as getFileMimeType } from './getFileMimeType';
 export { default as getFileContent } from './getFileContent';
+export { default as getFileEncoding } from './getFileEncoding';
+export { default as getFileExt } from './getFileExt';
+export { default as getFileMimeType } from './getFileMimeType';
+export { default as getFileName } from './getFileName';
 export { default as resolveFile } from './resolveFile';

--- a/src/helpers/getFixtureInfo.js
+++ b/src/helpers/getFixtureInfo.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import { getFileName } from '../../lib/file';
 
 export default function getFixtureInfo(fixtureInput) {
   if (typeof fixtureInput === 'string') {
@@ -6,7 +6,7 @@ export default function getFixtureInfo(fixtureInput) {
       filePath: fixtureInput,
       encoding: '',
       mimeType: '',
-      fileName: path.basename(fixtureInput),
+      fileName: getFileName(fixtureInput),
     };
   }
 
@@ -14,7 +14,7 @@ export default function getFixtureInfo(fixtureInput) {
     filePath: fixtureInput.filePath,
     encoding: fixtureInput.encoding || '',
     mimeType: fixtureInput.mimeType || '',
-    fileName: fixtureInput.fileName || path.basename(fixtureInput.filePath),
+    fileName: fixtureInput.fileName || getFileName(fixtureInput.filePath),
     fileContent: fixtureInput.fileContent,
     lastModified: fixtureInput.lastModified,
   };


### PR DESCRIPTION
#### Checklist:

- [x] No linting issues
- [x] Commits are compliant with commitizen
- [x] CI tests have passed
- [x] Documentation updated

#### Summary of changes

Replace Node.js module imports with own implementation.

#### Linked issues

Closes #301
Closes #250
Closes #236