### PR TITLE
Remove cypress types reference

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 declare namespace Cypress {
   type FixtureEncoding =
     | 'ascii'


### PR DESCRIPTION
Fixes #305

I admittedly don't understand what side-effect removing this line will have. I've only worked with types in TypeScript projects where the declarations file are generated by the TypeScript compiler rather than those written manually such as this. However, I don't think we need these types pulled in as a dependency here because you're not even using them - so they are just added to the global namespace without really adding any value.

Alos, Cypress users using TypeScript will already have cypress types pulled in with their tsconfig file, e.g. `"types": ["cypress"],`.

#### Checklist:

- [ ] No linting issues
- [ ] Commits are compliant with commitizen
- [ ] CI tests have passed
- [ ] Documentation updated

#### Summary of changes

_Please provide here description of how this PR changes the codebase and the
application and/or what bugs it fixes._

#### Linked issues

_You might use keyword combinations like"Closes #1" to link issues or other related PRs_
