### PR TITLE
fix: chromium should be handled the same way as chrome

### DIFF
--- a/lib/browser/isManualEventHandling.js
+++ b/lib/browser/isManualEventHandling.js
@@ -1,9 +1,9 @@
-const BROWSER_CHROME = 'chrome';
+const BROWSER_CHROME = ['chrome', 'chromium'];
 
 export default function isManualEventHandling() {
   const { name, majorVersion } = Cypress.browser;
 
-  if (name === BROWSER_CHROME && majorVersion < 73) {
+  if (BROWSER_CHROME.includes(name) && majorVersion < 73) {
     /**
      * Chrome <73 triggers 'change' event automatically
      * https://github.com/abramenal/cypress-file-upload/issues/34


### PR DESCRIPTION
#### Checklist:

- [x] No linting issues
- [x] Commits are compliant with commitizen
- [ ] CI tests have passed
- [ ] Documentation updated

#### Summary of changes

Chromium is the open source version of Chrome and some Cypress users in the ecosystem are forced to use it due to limitations in officially-supported Chrome ARM binaries for Linux.

This patch seeks to ensure that the same behaviors apply to Chromium as Chrome since they are effectively the same browser.